### PR TITLE
3-2-3 マイグレーションでデータベースにテーブルを追加する

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,2 @@
+class Task < ApplicationRecord
+end

--- a/db/migrate/20230612055456_create_tasks.rb
+++ b/db/migrate/20230612055456_create_tasks.rb
@@ -1,0 +1,10 @@
+class CreateTasks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tasks do |t|
+      t.string :name
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_06_12_055456) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end


### PR DESCRIPTION
## 概要
『現場で使える Ruby on Rails5 速習実践ガイド』の「3-2-3 マイグレーションでデータベースにテーブルを追加する」まで実施しました。
レビューのほどよろしくお願いいたします。

## 作業項目
* 3-2-1 タスクモデルの属性を設計する
* 3-2-2 タスクモデルのひな形を作成する
* 3-2-3 マイグレーションでデータベースにテーブルを追加する

## 主な作業内容
### 3-2-1 タスクモデルの属性を設計する
なし

### 3-2-2 タスクモデルのひな形を作成する
* Taskモデル、マイグレーションファイルの作成
`bin/rails g model Task name:string description:text`

### 3-2-3 マイグレーションでデータベースにテーブルを追加する
* マイグレーションの実行
`bin/rails db:migrate`

## スクリーンショット
画面上に変化がないため、割愛します。