### PR TITLE
3-3-5 削除機能を実装する

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -27,6 +27,12 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
+  def destroy
+    task = Task.find(params[:id])
+    task.destroy
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
+  end
+
   private
 
   def task_params

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,6 +17,16 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
   end
 
+  def edit
+    @task = Task.find(params[:id])
+  end
+
+  def update
+    task = Task.find(params[:id])
+    task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
+  end
+
   private
 
   def task_params

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,8 @@
+= form_with model: task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,8 +1,8 @@
 = form_with model: task, local: true do |f|
-  .form-group
+  .mb-3
     = f.label :name
     = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
+  .mb-3
     = f.label :description
     = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
   = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -3,11 +3,4 @@ h1 タスクの編集
 .nav-justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,0 +1,13 @@
+h1 タスクの編集
+
+.nav-justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,6 +1,6 @@
 h1 タスクの編集
 
-.nav-justify-content-end
+.nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
 = render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -15,4 +15,4 @@ table.table.table-hover
         td = task.created_at
         td
           = link_to '編集', edit_task_path(task), class: 'btn btn-primary me-3'
-          = link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'
+          = link_to '削除', task, data: { turbo_method: "delete", turbo_confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -14,4 +14,5 @@ table.table.table-hover
         td = link_to task.name, task
         td = task.created_at
         td
-          = link_to '編集', edit_task_path(task), class: 'btn btn-primary '
+          = link_to '編集', edit_task_path(task), class: 'btn btn-primary me-3'
+          = link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -7,8 +7,11 @@ table.table.table-hover
     tr
       th = Task.human_attribute_name(:name)
       th = Task.human_attribute_name(:created_at)
+      th
   tbody
     - @tasks.each do |task|
       tr
         td = link_to task.name, task
         td = task.created_at
+        td
+          = link_to '編集', edit_task_path(task), class: 'btn btn-primary '

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,6 +1,6 @@
 h1 タスクの新規登録
 
-.nav-justify-content-end
+.nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
 = render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,11 +3,4 @@ h1 タスクの新規登録
 .nav-justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -19,3 +19,5 @@ table.table.table-hover
     tr
       th = Task.human_attribute_name(:updated_at)
       td = @task.updated_at
+
+= link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -21,4 +21,4 @@ table.table.table-hover
       td = @task.updated_at
 
 = link_to '編集', edit_task_path, class: 'btn btn-primary me-3'
-= link_to '削除', @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'
+= link_to '削除', @task, data: { turbo_method: "delete", turbo_confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -20,4 +20,5 @@ table.table.table-hover
       th = Task.human_attribute_name(:updated_at)
       td = @task.updated_at
 
-= link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
+= link_to '編集', edit_task_path, class: 'btn btn-primary me-3'
+= link_to '削除', @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'


### PR DESCRIPTION
## 概要
『現場で使える Ruby on Rails5 速習実践ガイド』の「3-3-5 削除機能を実装する」まで実施しました。
レビューのほどよろしくお願いいたします。

## 作業項目
* 3-3-4 編集機能を実装する
* 3-3-5 削除機能を実装する

## 主な作業内容
### 3-3-4 編集機能を実装する
* 編集画面の作成
* 編集機能の実装
* 更新に関するフラッシュメッセージを実装
* 新規登録画面と編集画面を共通化

### 3-3-5 削除機能を実装する
* 削除時の確認ダイアログを実装
* 削除機能の実装
* 削除に関するフラッシュメッセージを実装

## スクリーンショット
* 編集画面
<img width="1440" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/9dbb443b-7b21-4d21-bc8d-81387f3007e1">

* タスクの更新
タスクの名称を「編集機能の実装」から「編集機能の作成」に変更
<img width="1440" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/e62dec45-1bbc-4476-9bb3-1c3c025d71a6">

* タスクの削除（確認ダイアログ）
<img width="1438" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/6c2432a1-4d43-46db-ab23-03b1ab93ae46">

* タスクの削除（フラッシュメッセージ）
<img width="1439" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/27a6f4eb-d0fe-496e-af93-b64a4ddc7c75">

