### PR TITLE
4-5-13 最初の管理ユーザーを作る

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
+    bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -244,6 +245,7 @@ PLATFORMS
   arm64-darwin-22
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   bootstrap
   capybara

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,8 @@
 class Admin::UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+
   def new
     @user = User.new
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,6 @@
 class Admin::UsersController < ApplicationController
+  before_action :require_admin
+
   def index
     @users = User.all
   end
@@ -45,5 +47,9 @@ class Admin::UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
+
+  def require_admin
+    redirect_to root_url unless current_user.admin?
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,21 @@
+class Admin::UsersController < ApplicationController
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を登録しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,6 +11,10 @@ class Admin::UsersController < ApplicationController
     @user = User.new
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
   def create
     @user = User.new(user_params)
 
@@ -18,6 +22,16 @@ class Admin::UsersController < ApplicationController
       redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を登録しました。"
     else
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @user = User.find(params[:id])
+
+    if @user.update(user_params)
+      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,6 +3,10 @@ class Admin::UsersController < ApplicationController
     @users = User.all
   end
 
+  def show
+    @user = User.find(params[:id])
+  end
+
   def new
     @user = User.new
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,6 +35,12 @@ class Admin::UsersController < ApplicationController
     end
   end
 
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to admin_users_url, notice: "ユーザー「#{@user.name}」を削除しました。"
+  end
+
   private
 
   def user_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  helper_method :current_user
+
+  private
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,14 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user
+  before_action :login_required
 
   private
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def login_required
+    redirect_to login_url unless current_user
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,6 +12,11 @@ class SessionsController < ApplicationController
     end
   end
 
+  def destroy
+    reset_session
+    redirect_to root_url, notice: 'ログアウトしました。'
+  end
+
   private
 
   def session_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,20 @@
+class SessionsController < ApplicationController
+  def new; end
+
+  def create
+    user = User.find_by(email: session_params[:email])
+
+    if user&.authenticate(session_params[:password])
+      session[:user_id] = user.id
+      redirect_to root_url, notice: 'ログインしました。'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email, :password)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :login_required
+  
   def new; end
 
   def create

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,10 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    @tasks = current_user.tasks
   end
 
   def show
-    @task = Task.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
   end
 
   def new
@@ -12,7 +12,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    @task = current_user.tasks.new(task_params)
 
     if @task.save
       redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"
@@ -22,17 +22,17 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = Task.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
   end
 
   def update
-    task = Task.find(params[:id])
+    task = current_user.tasks.find(params[:id])
     task.update!(task_params)
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
   def destroy
-    task = Task.find(params[:id])
+    task = current_user.tasks.find(params[:id])
     task.destroy
     redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,6 +2,8 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
   validate :validate_name_not_including_comma
 
+  belongs_to :user
+
   private
 
   def validate_name_not_including_comma

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
+
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
+
+  has_many :tasks
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+  has_secure_password
 end

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,0 +1,23 @@
+- if user.errors.present?
+  ul#error_explanation
+    - user.errors.full_messages.each do |message|
+      li= message
+
+= form_with model: [:admin, @user], local: true do |f|
+  .mb-3
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .mb-3
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control'
+  .form-check
+    = f.label :admin, class: 'form-check-label' do
+      = f.check_box :admin, class: 'form-check-input'
+      | 管理者権限
+  .mb-3
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control'
+  .mb-3
+    = f.label :password_confirmation, 'パスワード（確認）'
+    = f.password_field :password_confirmation, class: 'form-control'
+  = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -20,4 +20,4 @@
   .mb-3
     = f.label :password_confirmation, 'パスワード（確認）'
     = f.password_field :password_confirmation, class: 'form-control'
-  = f.submit '登録する', class: 'btn btn-primary'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,0 +1,20 @@
+h1 ユーザーの編集
+
+= form_with model: [:admin, @user], local: true do |f|
+  .mb-3
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .mb-3
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control'
+  .form-check
+    = f.label :admin, class: 'form-check-label' do
+      = f.check_box :admin, class: 'form-check-input'
+      | 管理者権限
+  .mb-3
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control'
+  .mb-3
+    = f.label :password_confirmation, 'パスワード（確認）'
+    = f.password_field :password_confirmation, class: 'form-control'
+  = f.submit '更新する', class: 'btn btn-primary'

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,20 +1,6 @@
 h1 ユーザーの編集
 
-= form_with model: [:admin, @user], local: true do |f|
-  .mb-3
-    = f.label :name, '名前'
-    = f.text_field :name, class: 'form-control'
-  .mb-3
-    = f.label :email, 'メールアドレス'
-    = f.text_field :email, class: 'form-control'
-  .form-check
-    = f.label :admin, class: 'form-check-label' do
-      = f.check_box :admin, class: 'form-check-input'
-      | 管理者権限
-  .mb-3
-    = f.label :password, 'パスワード'
-    = f.password_field :password, class: 'form-control'
-  .mb-3
-    = f.label :password_confirmation, 'パスワード（確認）'
-    = f.password_field :password_confirmation, class: 'form-control'
-  = f.submit '更新する', class: 'btn btn-primary'
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+
+= render partial: 'form', locals: { user: @user }

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,0 +1,24 @@
+h1 ユーザー一覧
+= link_to '新規登録', new_admin_user_path, class: 'btn btn-primary'
+
+.mb-3
+table.table.table-hover
+  thead.thead-default
+    tr
+      th = User.human_attribute_name(:name)
+      th = User.human_attribute_name(:email)
+      th = User.human_attribute_name(:admin)
+      th = User.human_attribute_name(:created_at)
+      th = User.human_attribute_name(:updated_at)
+      th
+  tbody
+    - @users.each do |user|
+      tr
+        td = link_to user.name, [:admin, user]
+        td = user.email
+        td = user.admin? ? 'あり' : 'なし'
+        td = user.created_at
+        td = user.updated_at
+        td
+          = link_to '編集', edit_admin_user_path(user), class: 'btn btn-primary me-3'
+          = link_to '削除', [:admin, user], data: { turbo_method: "delete", turbo_confirm: "ユーザー「#{user.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,0 +1,20 @@
+h1 ユーザー登録
+
+= form_with model: [:admin, @user], local: true do |f|
+  .mb-3
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .mb-3
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control'
+  .form-check
+    = f.label :admin, class: 'form-check-label' do
+      = f.check_box :admin, class: 'form-check-input'
+      | 管理者権限
+  .mb-3
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control'
+  .mb-3
+    = f.label :password_confirmation, 'パスワード（確認）'
+    = f.password_field :password_confirmation, class: 'form-control'
+  = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,20 +1,6 @@
 h1 ユーザー登録
 
-= form_with model: [:admin, @user], local: true do |f|
-  .mb-3
-    = f.label :name, '名前'
-    = f.text_field :name, class: 'form-control'
-  .mb-3
-    = f.label :email, 'メールアドレス'
-    = f.text_field :email, class: 'form-control'
-  .form-check
-    = f.label :admin, class: 'form-check-label' do
-      = f.check_box :admin, class: 'form-check-input'
-      | 管理者権限
-  .mb-3
-    = f.label :password, 'パスワード'
-    = f.password_field :password, class: 'form-control'
-  .mb-3
-    = f.label :password_confirmation, 'パスワード（確認）'
-    = f.password_field :password_confirmation, class: 'form-control'
-  = f.submit '登録する', class: 'btn btn-primary'
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+
+= render partial: 'form', locals: { user: @user }

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,0 +1,27 @@
+h1 ユーザーの詳細
+
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+table.table.table-hover
+  tbody
+    tr
+      th = User.human_attribute_name(:id)
+      td = @user.id
+    tr
+      th = User.human_attribute_name(:name)
+      td = @user.name
+    tr
+      th = User.human_attribute_name(:email)
+      td = @user.email
+    tr
+      th = User.human_attribute_name(:admin)
+      td = @user.admin? ? 'あり' : 'なし'
+    tr
+      th = User.human_attribute_name(:created_at)
+      td = @user.created_at
+    tr
+      th = User.human_attribute_name(:updated_at)
+      td = @user.updated_at
+
+= link_to '編集', edit_admin_user_path, class: 'btn btn-primary me-3'
+= link_to '削除', [:admin, @user], data: { turbo_method: "delete", turbo_confirm: "ユーザー「#{@user.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,7 +15,8 @@ html
       ul.navbar-nav.ms-auto
         - if current_user
           li.nav-item= link_to 'タスク一覧', tasks_path, class: 'nav-link'
-          li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
+          - if current_user.admin?
+            li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
           li.nav-item= link_to 'ログアウト', logout_path, data: { turbo_method: "delete" }, class: 'nav-link'
         - else
           li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,6 +11,14 @@ html
   body
     .app-title.navbar.navbar-expand-md.navbar-light.bg-light
       .navbar-brand Taskleaf
+
+      ul.navbar-nav.ms-auto
+        - if current_user
+          li.nav-item= link_to 'タスク一覧', tasks_path, class: 'nav-link'
+          li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
+          li.nav-item= link_to 'ログアウト', logout_path, data: { turbo_method: "delete" }, class: 'nav-link'
+        - else
+          li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'
     .container
       - if flash.notice.present?
         .alert.alert-success = flash.notice

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,0 +1,10 @@
+h1 ログイン
+
+= form_with scope: :session, local: true do |f|
+  .mb-3
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control', id: 'session_email'
+  .mb-3
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control', id: 'session_password'
+  = f.submit 'ログインする', class: 'btn btn-primary'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,15 @@ ja:
         description: 詳しい説明
         created_at: 登録日時
         updated_at: 更新日時
+      user:
+        id: ID
+        name: 名前
+        email: メールアドレス
+        admin: 管理者権限
+        password: パスワード
+        password_confirmation: パスワード（確認）
+        created_at: 登録日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
   namespace :admin do
     resources :users
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :users
+  end
   root to: 'tasks#index'
   resources :tasks
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
   namespace :admin do
     resources :users
   end

--- a/db/migrate/20230614063800_create_users.rb
+++ b/db/migrate/20230614063800_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+      t.index :email, unique: true
+    end
+  end
+end

--- a/db/migrate/20230614072744_add_admin_to_users.rb
+++ b/db/migrate/20230614072744_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230615024353_add_user_id_to_tasks.rb
+++ b/db/migrate/20230615024353_add_user_id_to_tasks.rb
@@ -1,0 +1,10 @@
+class AddUserIdToTasks < ActiveRecord::Migration[7.0]
+  def up
+    execute 'DELETE FROM tasks;'
+    add_reference :tasks, :user, null: false, index: true
+  end
+
+  def down
+    remove_reference :tasks, :user, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_12_055456) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_14_063800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_12_055456) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_14_072744) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_15_024353) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_14_072744) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_14_063800) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_14_072744) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_14_063800) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## 概要
『現場で使える Ruby on Rails5 速習実践ガイド』の「4-5-13 最初の管理ユーザーを作る」まで実施しました。
レビューのほどよろしくお願いいたします。

## 作業項目
* 4-5-1 セッションとCookie
* 4-5-2 Userモデルを作る
* 4-5-3 パスワードを受け付けてdigestを保存する
* 4-5-4 ユーザー管理機能一式を追加する
* 4-5-5 ログイン機能を実装する
* 4-5-6 ログインのフォームを表示する
* 4-5-7 ログインの実行
* 4-5-8 ログイン情報の取得を簡単にする
* 4-5-9 ログアウト機能を実装する
* 4-5-10 ログインしていなければタスク管理を利用できなくする
* 4-5-11 ログインしているユーザーのデータだけを扱えるようにする
* 4-5-12 管理機能を管理者ユーザーだけに利用させるようにする
* 4-5-13 最初の管理者ユーザーを作る

## 主な作業内容
### 4-5-1 セッションとCookie
なし

### 4-5-2 Userモデルを作る
* Userモデルの作成
`bin/rails g model user name:string email:string password_digest:string`

### 4-5-3 パスワードを受け付けてdigestを保存する
* Gem（bcrypt）のインストール
* has_secure_passwordの追加

### 4-5-4 ユーザー管理機能一式を追加する
* Userモデルにadminカラムを追加
`bin/rails g migration add_admin_to_users`
* ユーザーに関するCRUD機能を追加

### 4-5-5 ログイン機能を実装する
なし

### 4-5-6 ログインのフォームを表示する
* Sessionsコントローラを作成
`bin/rails g controller Sessions new`
* ログイン画面の作成

### 4-5-7 ログインの実行
* ログインに関するルーティングの設定
* ログイン機能の実装

### 4-5-8 ログイン情報の取得を簡単にする
* current_userメソッドの作成

### 4-5-9 ログアウト機能を実装する
* ログアウト機能の実装

### 4-5-10 ログインしていなければタスク管理を利用できなくする
* 未ログイン時、タスク管理が利用できない形に変更

### 4-5-11 ログインしているユーザーのデータだけを扱えるようにする
* Taskに外部キーuser_idを追加
`bin/rails g migration AddUserIdToTasks`
* TaskモデルとUserモデルの関連付けの追加
* ログインしているユーザーのタスクデータのみ操作できる形に変更

### 4-5-12 管理機能を管理者ユーザーだけに利用させるようにする
* ログインしているユーザーが管理権限を持っている場合のみ、ユーザーに関する操作ができる形に変更

### 4-5-13 最初の管理者ユーザーを作る
なし

## スクリーンショット
* ユーザー一覧画面
<img width="1440" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/f8dc9876-29eb-4b66-8cf6-fdeca2a075f4">

* ユーザー詳細画面
<img width="1440" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/6d6cd0e0-6dfa-43f7-be6f-58fb6d84ef03">

* ユーザー編集画面
<img width="1440" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/e05553d9-094a-4a36-a6e6-d083dde86625">

* ユーザーの編集完了（フラッシュメッセージ）
<img width="1440" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/95ac9bec-0c9e-486c-b870-010282446c9d">

* ユーザーの削除完了（フラッシュメッセージ）
<img width="1440" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/630f69e0-bae3-49e3-a4c8-ec0225bc50d4">

* ログイン画面
<img width="1440" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/85b4dfe2-6faf-4c75-b903-c14e7865ec9f">

* ログアウト時（フラッシュメッセージが表示される）
<img width="1440" alt="image" src="https://github.com/uchihiro04/taskleaf/assets/77523896/727b827d-12a5-4d5e-99ef-a8004924933d">


